### PR TITLE
Install v0.85 instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The script is run with the following arguments:
    Parameters:
    <0|1> means no/yes, ie. '-a 1' means 'install astrometry.net'
   
-     -a   install astrometry.net v0.76 and its dependencies.
+     -a   install astrometry.net v0.85 and its dependencies.
             Optional. If omitted, it will not be installed.
      -i   download astrometry.net index files, a comma separated
             string with index scale numbers, from 0 to 19,

--- a/scripts/installastrometry.sh
+++ b/scripts/installastrometry.sh
@@ -21,7 +21,7 @@ usage() {
   echo "Parameters:"
   echo "<0|1> means no/yes, ie. '-a 1' means 'install astrometry.net'"
   echo
-  echo "  -a   install astrometry.net v0.76 and its dependencies."
+  echo "  -a   install astrometry.net v0.85 and its dependencies."
   echo "         Optional. If omitted, it will not be installed."
   echo "  -i   download astrometry.net index files, a comma separated"
   echo "         string with index scale numbers, from 0 to 19,"
@@ -94,7 +94,7 @@ function install_astrometry() {
 
   # PIP and astropy
   curl https://bootstrap.pypa.io/get-pip.py | python
-  pip install --no-deps astropy
+  pip install astropy
 
   # CFITSIO
   curl -L -o cfitsio.tgz http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio3450.tar.gz
@@ -107,9 +107,9 @@ function install_astrometry() {
   ( cd wcslib-5.19.1 && ./configure LIBS="-pthread -lm" --without-pgplot --disable-fortran --prefix=/usr && make && make check && make install )
 
   # Astrometry.net
-  curl -L -o astrometry.tgz http://astrometry.net/downloads/astrometry.net-0.76.tar.gz
+  curl -L -o astrometry.tgz http://astrometry.net/downloads/astrometry.net-0.85.tar.gz
   tar zxvf astrometry.tgz
-  ( cd astrometry.net-0.76 && make && make py && make extra && make install INSTALL_DIR=/usr )
+  ( cd astrometry.net-0.85 && make && make py && make extra && make install INSTALL_DIR=/usr )
 
 }
 

--- a/scripts/installcygwin.bat
+++ b/scripts/installcygwin.bat
@@ -24,8 +24,8 @@ curl -o %SETUP_EXE% %SETUP_URL%
 REM -- These are the packages we will install (in addition to the default packages)
 SET PACKAGES=clang,wget,cmake,gcc-core,gsl,libX11-xcb-devel,libXdamage-devel,libXdamage1,libcairo-devel,libgsl-devel
 SET PACKAGES=%PACKAGES%,libgsl0,libgsl19,libjpeg-devel,libjpeg8,libnetpbm-devel,libnetpbm10,libpcre-devel
-SET PACKAGES=%PACKAGES%,libpixman1-devel,libxcb-glx-devel,libzip-devel,libzip2,make,netpbm,pkg-config,python2-devel
-SET PACKAGES=%PACKAGES%,python2-numpy,swig,zlib-devel
+SET PACKAGES=%PACKAGES%,libpixman1-devel,libxcb-glx-devel,libzip-devel,libzip2,make,netpbm,pkg-config,python38-devel
+SET PACKAGES=%PACKAGES%,python38-numpy,swig,zlib-devel
 
 REM -- Do it!
 ECHO *** INSTALLING PACKAGES


### PR DESCRIPTION
This installs astrometry.net v0.85, the current latest version, instead of v0.76. I have tested the scripts, except for the `download_indexes` function.

Nice scripts, by the way! They really saved me.